### PR TITLE
Docker isucon#1

### DIFF
--- a/isucon4-qualifier/README.md
+++ b/isucon4-qualifier/README.md
@@ -3,6 +3,27 @@
 ## Overview
 ISUCON4予選のDockerfile
 
+## usage(docker-compose)
+### 起動
+```
+$ sh ./app.sh start <lang>
+# if you wanna start go webapp
+$ sh ./app.sh start go
+```
+### 停止
+```
+$ sh ./app.sh stop <lang>
+# if you wanna stop go webapp
+$ sh ./app.sh stop go
+```
+
+### ベンチ
+```
+$ sh ./bench.sh <lang>
+```
+
+
+
 ## Usage(Standalone)
 
 ### 起動

--- a/isucon4-qualifier/README.md
+++ b/isucon4-qualifier/README.md
@@ -6,13 +6,13 @@ ISUCON4予選のDockerfile
 ## usage(docker-compose)
 ### 起動
 ```
-$ sh ./app.sh start <lang>
+$ sh ./app.sh start <lang> 
 # if you wanna start go webapp
-$ sh ./app.sh start go
+$ sh ./app.sh start go 
 ```
 ### 停止
 ```
-$ sh ./app.sh stop <lang>
+$ sh ./app.sh stop <lang> 
 # if you wanna stop go webapp
 $ sh ./app.sh stop go
 ```
@@ -21,6 +21,17 @@ $ sh ./app.sh stop go
 ```
 $ sh ./bench.sh <lang>
 ```
+### webapp取得先ブランチ変更(go オンリー)
+* Dockerfile20行目の
+  
+    `ADD "https://api.github.com/repos/mattsu6/isucon4/git/refs/heads/<branch>" version.json`
+    の`<branch>`部分をブランチ名に変更
+
+* Dockerfile22行目の
+
+    `git clone -b <branch> https://github.com/mattsu6/isucon4.git`
+    の`<branch>`部分をブランチ名に変更
+
 
 
 

--- a/isucon4-qualifier/app.sh
+++ b/isucon4-qualifier/app.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if test $1 = "start"; then
+    docker-compose --file "docker-compose-${2}.yml" up --build -d nginx;
+elif test $1 = "stop"; then
+    docker-compose --file "docker-compose-${2}.yml" stop;
+else 
+    echo "引数はstartかstopのみ許されている.";
+    exit 1;
+fi

--- a/isucon4-qualifier/bench.sh
+++ b/isucon4-qualifier/bench.sh
@@ -1,0 +1,1 @@
+docker-compose --file "docker-compose-${1}.yml" up bench

--- a/isucon4-qualifier/docker-compose-go.yml
+++ b/isucon4-qualifier/docker-compose-go.yml
@@ -6,14 +6,14 @@ services:
       - nginx
       - mysql
   nginx:
-    build: /Users/kojiMac/IdeaProjects/docker-isucon/isucon4-qualifier/nginx
+    build: nginx
     links:
       - webapp
     ports:
       - "80:80"
   webapp:
     #image: matsuu/isucon4-qualifier-webapp-go:latest
-    build: /Users/kojiMac/IdeaProjects/docker-isucon/isucon4-qualifier/webapp/go
+    build: webapp/go
     links:
        - mysql
     ports:

--- a/isucon4-qualifier/webapp/go/Dockerfile
+++ b/isucon4-qualifier/webapp/go/Dockerfile
@@ -16,8 +16,8 @@ RUN \
   chmod a+x prebuild.sh \
   ./prebuild.sh
 
-# ダミーファイルを読んで以下処理をbuildするようにする
-ADD "https://api.github.com/repos/mattsu6/isucon4/git/refs/heads/#1" version.json
+# ブランチの更新を見て以下を再ビルドします
+ADD "https://api.github.com/repos/mattsu6/isucon4/git/refs/heads/master" version.json
 RUN  \
   git clone -b mattsu https://github.com/mattsu6/isucon4.git && \
   mkdir /tmp/isucon && \

--- a/isucon4-qualifier/webapp/go/Dockerfile
+++ b/isucon4-qualifier/webapp/go/Dockerfile
@@ -2,11 +2,23 @@ FROM centos:6
 
 MAINTAINER matsuu@gmail.com
 
+# 時間がかかるyum updateおよびgolangのダウンロードおよび展開をキャッシュ化
 RUN \
   yum -y update && \
   yum -y install git mysql sudo && \
   useradd -G wheel isucon && \
   echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+  curl -L http://golang.org/dl/go1.10.3.linux-amd64.tar.gz | tar zxf - -C /usr/local
+
+# goの依存関係の一部を先に打ち込む
+COPY prebuild.sh .
+RUN \
+  chmod a+x prebuild.sh \
+  ./prebuild.sh
+
+# ダミーファイルを読んで以下処理をbuildするようにする
+ADD "https://api.github.com/repos/mattsu6/isucon4/git/refs/heads/#1" version.json
+RUN  \
   git clone -b mattsu https://github.com/mattsu6/isucon4.git && \
   mkdir /tmp/isucon && \
   rsync -a isucon4/qualifier/sql /tmp/isucon/ && \
@@ -26,9 +38,7 @@ RUN \
   rm -rf isucon4 /tmp/isucon
 
 WORKDIR /home/isucon/webapp/go
-RUN \
-  curl -L http://golang.org/dl/go1.10.3.linux-amd64.tar.gz | tar zxf - -C /usr/local && \
-  /home/isucon/env.sh ./build.sh 
+RUN /home/isucon/env.sh ./build.sh 
 
 EXPOSE 8080
 CMD ["/home/isucon/env.sh", "./golang-webapp"]

--- a/isucon4-qualifier/webapp/go/prebuild.sh
+++ b/isucon4-qualifier/webapp/go/prebuild.sh
@@ -1,0 +1,4 @@
+go get github.com/go-martini/martini
+go get github.com/go-sql-driver/mysql
+go get github.com/martini-contrib/render
+go get github.com/martini-contrib/sessions


### PR DESCRIPTION
#1 
## 方策
Dockerfileのcentosのビルド部分、golang自体のインストール及び依存関係の解決部分についてキャッシュ化するような処理を加えた

起動、停止のコマンドが長いのでscript化した.
`sh ./app <start | stop> <go|ruby|...lang>` が許される.


