### PR TITLE
dockerfileのキャッシュ部分をdockerhubへ上げてイメージ化

### DIFF
--- a/isucon4-qualifier/webapp/go/Dockerfile
+++ b/isucon4-qualifier/webapp/go/Dockerfile
@@ -1,21 +1,4 @@
-FROM centos:6
-
-MAINTAINER matsuu@gmail.com
-
-# 時間がかかるyum updateおよびgolangのダウンロードおよび展開をキャッシュ化
-RUN \
-  yum -y update && \
-  yum -y install git mysql sudo && \
-  useradd -G wheel isucon && \
-  echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-  curl -L http://golang.org/dl/go1.10.3.linux-amd64.tar.gz | tar zxf - -C /usr/local
-
-# goの依存関係の一部を先に打ち込む
-COPY prebuild.sh .
-RUN \
-  chmod a+x prebuild.sh \
-  ./prebuild.sh
-
+FROM tosukui/docker-isucon4-webapp-go-cache:1
 # ブランチの更新を見て以下を再ビルドします
 ADD "https://api.github.com/repos/mattsu6/isucon4/git/refs/heads/master" version.json
 RUN  \

--- a/isucon4-qualifier/webapp/go/dockerfile-for-cache/Dockerfile
+++ b/isucon4-qualifier/webapp/go/dockerfile-for-cache/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:6
+
+# 本dockerfileはtosukui/docker-isucon4-webapp-go-cacheにあります
+
+MAINTAINER am.businessmail.exp@gmail.com
+
+# 時間がかかるyum updateおよびgolangのダウンロードおよび展開をキャッシュ化
+RUN \
+  yum -y update && \
+  yum -y install git mysql sudo && \
+  useradd -G wheel isucon && \
+  echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+  curl -L http://golang.org/dl/go1.10.3.linux-amd64.tar.gz | tar zxf - -C /usr/local


### PR DESCRIPTION
# 概要
以前キャッシュ化していた部分をdockerhubへアップロードしイメージ化
webapp/go/Dockerfileのgo getの部分でgoの環境がないエラーが出ていた部分を削除して解決
